### PR TITLE
refactor!: RunUntilStopped now accepts a chan <-struct{} instead of chan <-interface{}

### DIFF
--- a/golang/server/server_test.go
+++ b/golang/server/server_test.go
@@ -8,32 +8,32 @@ import (
 )
 
 const (
-	listenPort = uint16(9003)
+	listenPort      = uint16(9003)
 	stopGracePeriod = 10 * time.Second
 )
 
 func TestManualShutdown(t *testing.T) {
 	server := NewMinimalGRPCServer(listenPort, stopGracePeriod, []func(*grpc.Server){})
 
-	stopChan := make(chan interface{})
+	stopChan := make(chan struct{})
 	runResultChan := make(chan error)
 	go func() {
 		runResultChan <- server.RunUntilStopped(stopChan)
 	}()
 	select {
-	case err := <- runResultChan:
+	case err := <-runResultChan:
 		t.Fatalf("The server unexpectedly returned a result before we sent a signal to stop it:\n%v", err)
-	case <- time.After(1 * time.Second):
+	case <-time.After(1 * time.Second):
 		// Nothing
 	}
-	stopChan <- "Stop now"
+	stopChan <- struct{}{}
 
 	maxWaitForServerToStop := 1 * time.Second
 	var errAfterStop error
 	select {
-	case errAfterStop = <- runResultChan:
+	case errAfterStop = <-runResultChan:
 		// Assignment is all we have to do
-	case <- time.After(maxWaitForServerToStop):
+	case <-time.After(maxWaitForServerToStop):
 		t.Fatalf("Expected the server to have stopped after %v, but it didn't", maxWaitForServerToStop)
 	}
 	assert.NoError(t, errAfterStop, "Expected the server to exit without an error but it threw the following:\n%v", errAfterStop)


### PR DESCRIPTION
Actually achieving what's described in https://github.com/kurtosis-tech/minimal-grpc-server/pull/32#issuecomment-1471766923
 returns a  and not a ...